### PR TITLE
fix macOS build

### DIFF
--- a/tests/TestSuite.hs
+++ b/tests/TestSuite.hs
@@ -22,8 +22,7 @@ import           Control.Exception
 
 -- #define _UPK_(x) {-# UNPACK #-} !(x)
 
-
-#define shouldRun(x) (local $ getMyNode >>= \p -> assert ( p == (x)) (return ()))
+shouldRun x = local $ getMyNode >>= \p -> assert ( p == (x)) (return ())
 
 
 service= [("service","test suite")


### PR DESCRIPTION
`stack build` fail on macOS with

~~~
...transient-universe/tests/TestSuite.hs:84:35: Not in scope: ‘shouldRun’
~~~

Also adding the dependency to `transient-universe-0.4.6.1` to a freshly created project with stack will fail to compile on macOS for the same reason.

That appear to fix the problem. Apparently macOS has difficulty to handle `#define`.